### PR TITLE
feat: allow anonymous default export of arrays and objects

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,3 @@
-const config = {
+export default {
 	extends: ['@commitlint/config-conventional'],
 };
-
-export default config;

--- a/index.js
+++ b/index.js
@@ -11,6 +11,13 @@ export default defineConfig([
 			eslintConfigXo({browser: true}),
 			jsdoc.configs['flat/recommended'],
 		],
+		rules: {
+			'import-x/no-anonymous-default-export': ['error', {
+				allowArray: true,
+				allowLiteral: true,
+				allowObject: true,
+			}],
+		},
 	},
 	{
 		files: ['**/*.json'],


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

[This rule](https://github.com/un-ts/eslint-plugin-import-x/blob/v4.16.2/docs/rules/no-anonymous-default-export.md) came into effect and IMHO it's not necessary for some of our use cases. Under its default settings, this is an error:

```javascript
export default {
	extends: ['@commitlint/config-conventional'],
};
```

This is not:

```javascript
const config = {
	extends: ['@commitlint/config-conventional'],
};

export default config;
```

The goal of the rule seems to be to ensure consistency when importing from exports which makes sense for functions and classes but I think it's overkill for it to force us to create a named variable and then export the variable for a config object.

## Steps to test

1. Run eslint.

**Expected behavior:** No violations detected for this rule.

## Additional information

https://github.com/un-ts/eslint-plugin-import-x/blob/v4.16.2/docs/rules/no-anonymous-default-export.md

## Related issues

_Not provided._
